### PR TITLE
[MARKET-311] Add console polyfill to avoid breaking in embedded IE

### DIFF
--- a/marketplace-ba/src/main/resources/web/main.html
+++ b/marketplace-ba/src/main/resources/web/main.html
@@ -20,6 +20,8 @@
   <head>
     <title>Marketplace</title>
 
+    <script src="js/console-polyfill.js"></script>
+
     <!-- this is important, it provides theming and the base url -->
     <script type="text/javascript" src="webcontext.js?context=marketplace"></script>
 

--- a/marketplace-core/src/main/resources/web/js/console-polyfill.js
+++ b/marketplace-core/src/main/resources/web/js/console-polyfill.js
@@ -1,0 +1,20 @@
+// Console-polyfill. MIT license.
+// https://github.com/paulmillr/console-polyfill
+// Make it safe to do console.log() always.
+(function(global) {
+  'use strict';
+  global.console = global.console || {};
+  var con = global.console;
+  var prop, method;
+  var empty = {};
+  var dummy = function() {};
+  var properties = 'memory'.split(',');
+  var methods = ('assert,clear,count,debug,dir,dirxml,error,exception,group,' +
+     'groupCollapsed,groupEnd,info,log,markTimeline,profile,profiles,profileEnd,' +
+     'show,table,time,timeEnd,timeline,timelineEnd,timeStamp,trace,warn').split(',');
+  while (prop = properties.pop()) if (!con[prop]) con[prop] = empty;
+  while (method = methods.pop()) if (!con[method]) con[method] = dummy;
+})(typeof window === 'undefined' ? this : window);
+// Using `this` for web workers while maintaining compatibility with browser
+// targeted script loaders such as Browserify or Webpack where the only way to
+// get to the global object is via `window`.

--- a/marketplace-core/src/main/resources/web/main.html
+++ b/marketplace-core/src/main/resources/web/main.html
@@ -3,6 +3,8 @@
     <head>
         <title>Marketplace</title>
 
+        <script src="js/console-polyfill.js"></script>
+
         <!-- this is important, it provides theming and the base url -->
         <!-- <script type="text/javascript" src="webcontext.js?context=marketplace"></script> -->
 

--- a/marketplace-di/src/main/resources/web/main.html
+++ b/marketplace-di/src/main/resources/web/main.html
@@ -20,6 +20,8 @@
     <head>
         <title>Marketplace</title>
 
+        <script src="js/console-polyfill.js"></script>
+
         <!-- this is important, it provides theming and the base url -->
         <!-- <script type="text/javascript" src="webcontext.js?context=marketplace"></script> -->
 


### PR DESCRIPTION
Older versions of IE, particularly embedded ones and some other browsers/configurations, don't provide the window.console object if no Developer Tools are open/exist at all.

`console.log` and other should be avoided in production code (maybe removed during build), but the polyfill prevents the error in case any slips through and during development.