### PR TITLE
[MARKET-311] Add marketplace/Logger module, replacing all references to console.log

### DIFF
--- a/marketplace-core/src/main/resources/META-INF/js/require.json
+++ b/marketplace-core/src/main/resources/META-INF/js/require.json
@@ -4,6 +4,7 @@
   "paths": {
     "org.pentaho.marketplace.di.plugin.web": "marketplace/web",
     "marketplace": "marketplace/web",
+    "marketplace-lib": "marketplace/web/lib/marketplace",
     "marketplaceApp": "marketplace/web/js/app",
     "angular-translate": "marketplace/web/lib/angular-translate/angular-translate",
     "ui-bootstrap": "marketplace/web/lib/ui-bootstrap-tpls-0.6.0.min",

--- a/marketplace-core/src/main/resources/web/directives/devStageIcon/devStageIconController.js
+++ b/marketplace-core/src/main/resources/web/directives/devStageIcon/devStageIconController.js
@@ -13,9 +13,9 @@
 
 'use strict';
 
-define( [ 'marketplaceApp' ],
-    function ( app ) {
-      console.log("Required devStageIcon/devStageIconController.js");
+define( [ 'marketplaceApp', 'marketplace-lib/Logger' ],
+    function ( app, logger ) {
+      logger.log("Required devStageIcon/devStageIconController.js");
 
       app.controller('devStageIconController',
           ['$scope', 'developmentStageService',

--- a/marketplace-core/src/main/resources/web/directives/devStageIcon/devStageIconDirective.js
+++ b/marketplace-core/src/main/resources/web/directives/devStageIcon/devStageIconDirective.js
@@ -13,9 +13,9 @@
 
 'use strict';
 
-define( [ 'marketplaceApp' ],
-    function ( app ) {
-      console.log("Required devStageIcon/devStageIconDirective.js");
+define( [ 'marketplaceApp', 'marketplace-lib/Logger' ],
+    function ( app, logger ) {
+      logger.log("Required devStageIcon/devStageIconDirective.js");
 
       app.directive('devStageIcon',
           function() {

--- a/marketplace-core/src/main/resources/web/directives/indeterminate/indeterminateDirective.js
+++ b/marketplace-core/src/main/resources/web/directives/indeterminate/indeterminateDirective.js
@@ -19,9 +19,10 @@
  * @example <input type="checkbox" data-indeterminate="isUnknown">
  */
 define( [ 'marketplaceApp',
-          'angular' ],
-    function ( app, angular ) {
-      console.log("Required directives/indeterminate/indeterminateDirective.js");
+          'angular',
+          'marketplace-lib/Logger' ],
+    function ( app, angular, logger ) {
+      logger.log("Required directives/indeterminate/indeterminateDirective.js");
 
       app.directive('indeterminate', function () {
           return {

--- a/marketplace-core/src/main/resources/web/directives/installUpdateButton/installUpdateButtonController.js
+++ b/marketplace-core/src/main/resources/web/directives/installUpdateButton/installUpdateButtonController.js
@@ -14,9 +14,9 @@
 'use strict';
 
 define( [
-      'marketplaceApp' ],
-    function ( app ) {
-      console.log("Required installUpdateButton/installUpdateButton.js");
+      'marketplaceApp', 'marketplace-lib/Logger' ],
+    function ( app, logger ) {
+      logger.log("Required installUpdateButton/installUpdateButton.js");
 
       app.controller('installUpdateButtonController',
           ['$scope', 'installFlowService',

--- a/marketplace-core/src/main/resources/web/directives/installUpdateButton/installUpdateButtonDirective.js
+++ b/marketplace-core/src/main/resources/web/directives/installUpdateButton/installUpdateButtonDirective.js
@@ -13,10 +13,10 @@
 
 'use strict';
 
-define( [ 'marketplaceApp' ],
-    function ( app ) {
+define( [ 'marketplaceApp', 'marketplace-lib/Logger' ],
+    function ( app, logger ) {
 
-      console.log("Required installUpdateButton/installUpdateButtonDirective.js");
+      logger.log("Required installUpdateButton/installUpdateButtonDirective.js");
 
       app.directive('installUpdateButton', function() {
         return {

--- a/marketplace-core/src/main/resources/web/directives/modalHeight/modalHeightDirective.js
+++ b/marketplace-core/src/main/resources/web/directives/modalHeight/modalHeightDirective.js
@@ -15,10 +15,11 @@
 
 define( [
       'marketplaceApp',
-      'angular'
+      'angular',
+      'marketplace-lib/Logger'
     ],
-    function ( app, angular ) {
-      console.log("Required modalHeightDirective.js");
+    function ( app, angular, logger ) {
+      logger.log("Required modalHeightDirective.js");
 
       app.directive('modalHeight', ['$timeout', '$window',
           function( timer, window ) {

--- a/marketplace-core/src/main/resources/web/directives/multiselectDropdown/multiselectDropdownController.js
+++ b/marketplace-core/src/main/resources/web/directives/multiselectDropdown/multiselectDropdownController.js
@@ -16,10 +16,11 @@
 define(
     [
       'marketplaceApp',
-      'underscore'
+      'underscore',
+      'marketplace-lib/Logger'
     ],
-    function ( app, _ ) {
-      console.log("Required multiselectDropdown/multiselectDropdownController.js");
+    function ( app, _, logger ) {
+      logger.log("Required multiselectDropdown/multiselectDropdownController.js");
 
       app.controller('multiselectDropdownController',
           ['$scope',

--- a/marketplace-core/src/main/resources/web/directives/multiselectDropdown/multiselectDropdownDirective.js
+++ b/marketplace-core/src/main/resources/web/directives/multiselectDropdown/multiselectDropdownDirective.js
@@ -26,9 +26,9 @@
 
 'use strict';
 
-define( [ 'marketplaceApp' ],
-    function ( app ) {
-      console.log("Required multiselectDropdown/multiselectDropdownDirective.js");
+define( [ 'marketplaceApp', 'marketplace-lib/Logger' ],
+    function ( app, logger ) {
+      logger.log("Required multiselectDropdown/multiselectDropdownDirective.js");
 
       app.directive('multiselectDropdown',
           function() {

--- a/marketplace-core/src/main/resources/web/directives/pluginDetail/pluginDetailController.js
+++ b/marketplace-core/src/main/resources/web/directives/pluginDetail/pluginDetailController.js
@@ -16,11 +16,12 @@
 
 define( [
       'marketplaceApp',
-      'underscore'
+      'underscore',
+      'marketplace-lib/Logger'
     ],
-    function ( app, _ ) {
+    function ( app, _, logger ) {
 
-      console.log("Required pluginDetail/pluginDetailController.js");
+      logger.log("Required pluginDetail/pluginDetailController.js");
 
       app.controller( 'pluginDetailController',
           ['$scope', 'installFlowService', '$translate',

--- a/marketplace-core/src/main/resources/web/directives/pluginDetail/pluginDetailDirective.js
+++ b/marketplace-core/src/main/resources/web/directives/pluginDetail/pluginDetailDirective.js
@@ -13,10 +13,10 @@
 
 'use strict';
 
-define( [ 'marketplaceApp' ],
-    function ( app ) {
+define( [ 'marketplaceApp', 'marketplace-lib/Logger' ],
+    function ( app, logger ) {
 
-      console.log("Required pluginDetail/pluginDetailDirective.js");
+      logger.log("Required pluginDetail/pluginDetailDirective.js");
 
       app.directive('pluginDetail', function() {
         return {

--- a/marketplace-core/src/main/resources/web/directives/pluginList/pluginListController.js
+++ b/marketplace-core/src/main/resources/web/directives/pluginList/pluginListController.js
@@ -13,10 +13,10 @@
 
 'use strict';
 
-define( [ 'marketplaceApp' ],
-    function ( app ) {
+define( [ 'marketplaceApp', 'marketplace-lib/Logger' ],
+    function ( app, logger ) {
 
-      console.log("Required pluginList/pluginListController.js");
+      logger.log("Required pluginList/pluginListController.js");
 
       app.controller('pluginListController',
           ['$scope', 'appService',

--- a/marketplace-core/src/main/resources/web/directives/pluginList/pluginListDirective.js
+++ b/marketplace-core/src/main/resources/web/directives/pluginList/pluginListDirective.js
@@ -13,9 +13,9 @@
 
 'use strict';
 
-define( [ 'marketplaceApp' ],
-    function ( app ) {
-      console.log("Required pluginList/pluginListDirective.js");
+define( [ 'marketplaceApp', 'marketplace-lib/Logger' ],
+    function ( app, logger ) {
+      logger.log("Required pluginList/pluginListDirective.js");
 
       app.directive('pluginList',
           function() {

--- a/marketplace-core/src/main/resources/web/directives/pluginListItem/pluginListItemController.js
+++ b/marketplace-core/src/main/resources/web/directives/pluginListItem/pluginListItemController.js
@@ -13,9 +13,9 @@
 
 'use strict';
 
-define( [ 'marketplaceApp' ],
-    function ( app ) {
-      console.log("Required pluginListItem/pluginListItemController.js");
+define( [ 'marketplaceApp', 'marketplace-lib/Logger' ],
+    function ( app, logger ) {
+      logger.log("Required pluginListItem/pluginListItemController.js");
 
       app.controller('pluginListItemController',
           ['$scope',

--- a/marketplace-core/src/main/resources/web/directives/pluginListItem/pluginListItemDirective.js
+++ b/marketplace-core/src/main/resources/web/directives/pluginListItem/pluginListItemDirective.js
@@ -13,9 +13,9 @@
 
 'use strict';
 
-define( [ 'marketplaceApp' ],
-    function ( app ) {
-      console.log("Required pluginListItem/pluginListItemDirective.js");
+define( [ 'marketplaceApp', 'marketplace-lib/Logger' ],
+    function ( app, logger ) {
+      logger.log("Required pluginListItem/pluginListItemDirective.js");
 
       app.directive('pluginListItem',
           function() {

--- a/marketplace-core/src/main/resources/web/directives/stagesInfo/stagesInfoController.js
+++ b/marketplace-core/src/main/resources/web/directives/stagesInfo/stagesInfoController.js
@@ -14,10 +14,11 @@
 'use strict';
 
 define( [ 'marketplaceApp',
-      'underscore'
+      'underscore',
+      'marketplace-lib/Logger'
     ],
-    function ( app, _ ) {
-      console.log("Required stagesInfo/stagesInfoController.js");
+    function ( app, _, logger ) {
+      logger.log("Required stagesInfo/stagesInfoController.js");
 
       app.controller('stagesInfoController',
           ['$scope', 'developmentStageService',

--- a/marketplace-core/src/main/resources/web/directives/stagesInfo/stagesInfoDirective.js
+++ b/marketplace-core/src/main/resources/web/directives/stagesInfo/stagesInfoDirective.js
@@ -13,9 +13,9 @@
 
 'use strict';
 
-define( [ 'marketplaceApp' ],
-    function ( app ) {
-      console.log("Required stagesInfo/stagesInfoDirective.js");
+define( [ 'marketplaceApp', 'marketplace-lib/Logger' ],
+    function ( app, logger ) {
+      logger.log("Required stagesInfo/stagesInfoDirective.js");
 
       app.directive('stagesInfo',
           function() {

--- a/marketplace-core/src/main/resources/web/directives/stopEvent/stopEventDirective.js
+++ b/marketplace-core/src/main/resources/web/directives/stopEvent/stopEventDirective.js
@@ -12,9 +12,9 @@
  */
 
 'use strict';
-define( [ 'marketplaceApp' ],
-    function ( app ) {
-      console.log("Required stopEvent/stopEventDirective.js");
+define( [ 'marketplaceApp', 'marketplace-lib/Logger' ],
+    function ( app, logger ) {
+      logger.log("Required stopEvent/stopEventDirective.js");
 
       app.directive('stopEvent', function () {
         return {

--- a/marketplace-core/src/main/resources/web/js/app.js
+++ b/marketplace-core/src/main/resources/web/js/app.js
@@ -16,12 +16,13 @@
 define( [ 'angular',
           'angular-route',
           'ui-bootstrap',
-          'angular-translate'
+          'angular-translate',
+          'marketplace-lib/Logger'
     ],
 
-    function ( angular, angularRoute, uiBootstrap ) {
+    function ( angular, angularRoute, uiBootstrap, angularTranslate, logger ) {
 
-      console.log("Required app.js ");
+      logger.log("Required app.js ");
 
       // define application module
       var app = angular.module( 'marketplace', [ 'ngRoute', 'ui.bootstrap', 'ngSanitize', 'pascalprecht.translate' ] );

--- a/marketplace-core/src/main/resources/web/js/controllers/applicationController.js
+++ b/marketplace-core/src/main/resources/web/js/controllers/applicationController.js
@@ -16,11 +16,12 @@
 define(
     [
       'marketplaceApp',
-      'underscore'
+      'underscore',
+      'marketplace-lib/Logger'
     ],
-    function ( app, _ ) {
+    function ( app, _, logger ) {
 
-      console.log("Required controllers/applicationController.js");
+      logger.log("Required controllers/applicationController.js");
 
       app.controller('applicationController',
           ['$scope', 'appService', '$modal', 'developmentStageService', '$filter',

--- a/marketplace-core/src/main/resources/web/js/models/plugin.js
+++ b/marketplace-core/src/main/resources/web/js/models/plugin.js
@@ -14,11 +14,12 @@
 define(
     [
       'marketplaceApp',
-      'underscore'
+      'underscore',
+      'marketplace-lib/Logger'
     ],
-    function ( app, _ ) {
+    function ( app, _, logger ) {
 
-      console.log("Required models/plugin.js");
+      logger.log("Required models/plugin.js");
 
       app.factory('Plugin',
           [

--- a/marketplace-core/src/main/resources/web/js/services/appService.js
+++ b/marketplace-core/src/main/resources/web/js/services/appService.js
@@ -16,10 +16,11 @@
 define(
     [
       'marketplaceApp',
-      'underscore'
+      'underscore',
+      'marketplace-lib/Logger'
     ],
-    function ( app, _ ) {
-      console.log("Required services/appService.js");
+    function ( app, _, logger ) {
+      logger.log("Required services/appService.js");
 
       app.factory('appService',
           [ '$http', 'dtoMapperService', '$q', 'BASE_URL',
@@ -44,7 +45,7 @@ define(
                         function ( response ) {
                           var dto = response.data;
                           if ( isResponseError( response ) ) {
-                            console.log( "Failed getting plugins from server." );
+                            logger.log( "Failed getting plugins from server." );
                             return $q.reject( dto.statusMessage );
                           }
                           return _.map( dto.plugins, dtoMapper.toPlugin );
@@ -64,42 +65,42 @@ define(
                 },
 
                 installPlugin: function ( plugin, version ) {
-                  console.log("Installing " + plugin.id + " " + version.branch );
+                  logger.log("Installing " + plugin.id + " " + version.branch );
                   return $http.post( installPluginBaseUrl + '/' + plugin.id + '/' + version.branch)
                       .then( function ( response ) {
                         if ( isResponseError( response ) ) {
-                          console.log("Install NOT OK. plugin Id: " + plugin.id + " branch: " + version.branch);
+                          logger.log("Install NOT OK. plugin Id: " + plugin.id + " branch: " + version.branch);
                           return $q.reject(response.data.statusMessage);
                         }
                         // TODO: verify in response if everything is actually ok
-                        console.log("Install OK. plugin Id: " + plugin.id + " branch: " + version.branch);
+                        logger.log("Install OK. plugin Id: " + plugin.id + " branch: " + version.branch);
                         plugin.isInstalled = true;
                         plugin.installedVersion = version;
 
                       },
                       function ( response ) {
-                        console.log("Install NOT OK. plugin Id: " + plugin.id + " branch: " + version.branch);
+                        logger.log("Install NOT OK. plugin Id: " + plugin.id + " branch: " + version.branch);
                         return $q.reject( response );
                       });
                 },
 
                 uninstallPlugin: function ( plugin ) {
                   // TODO: change to log when dialogs are handled
-                  console.log( "Uninstalling " + plugin.id );
+                  logger.log( "Uninstalling " + plugin.id );
                   // Not using the shortcut method $http.delete because it does not work in IE8
                   return $http( { method: 'DELETE', url: installPluginBaseUrl + '/' + plugin.id } )
                       .then( function ( response ) {
                         if ( isResponseError( response ) ) {
-                          console.log( "Uninstall NOT OK. plugin Id: " + plugin.id );
+                          logger.log( "Uninstall NOT OK. plugin Id: " + plugin.id );
                           return $q.reject(response.data.statusMessage);
                         }
                         // TODO: verify in response if everything is actually ok
-                        console.log( "Uninstall OK. plugin Id: " + plugin.id );
+                        logger.log( "Uninstall OK. plugin Id: " + plugin.id );
                         plugin.isInstalled = false;
                         plugin.installedVersion = undefined;
                       },
                       function ( response ) {
-                        console.log( "Uninstall NOT OK. plugin Id: " + plugin.id );
+                        logger.log( "Uninstall NOT OK. plugin Id: " + plugin.id );
                         return $q.reject( response );
                       });
                 }

--- a/marketplace-core/src/main/resources/web/js/services/categoryService.js
+++ b/marketplace-core/src/main/resources/web/js/services/categoryService.js
@@ -17,10 +17,11 @@
 define(
     [
       'marketplaceApp',
-      'underscore'
+      'underscore',
+      'marketplace-lib/Logger'
     ],
-    function ( app, _ ) {
-      console.log("Required services/categoryService.js");
+    function ( app, _, logger ) {
+      logger.log("Required services/categoryService.js");
 
       var service = app.factory( 'categoryService',
           [ '$translate',

--- a/marketplace-core/src/main/resources/web/js/services/developmentStageService.js
+++ b/marketplace-core/src/main/resources/web/js/services/developmentStageService.js
@@ -17,10 +17,11 @@
 define(
     [
       'marketplaceApp',
-      'underscore'
+      'underscore',
+      'marketplace-lib/Logger'
     ],
-    function ( app, _ ) {
-      console.log("Required services/developmentStageService.js");
+    function ( app, _, logger ) {
+      logger.log("Required services/developmentStageService.js");
 
       var service = app.factory( 'developmentStageService',
           [ '$translate',

--- a/marketplace-core/src/main/resources/web/js/services/dtoMapperService.js
+++ b/marketplace-core/src/main/resources/web/js/services/dtoMapperService.js
@@ -17,10 +17,11 @@
 define(
     [
       'marketplaceApp',
-      'underscore'
+      'underscore',
+      'marketplace-lib/Logger'
     ],
-    function ( app, _ ) {
-      console.log("Required services/dtoMapperService.js");
+    function ( app, _, logger ) {
+      logger.log("Required services/dtoMapperService.js");
 
       var service = app.factory( 'dtoMapperService',
           [ 'Plugin', 'developmentStageService', 'categoryService',

--- a/marketplace-core/src/main/resources/web/js/services/installFlowService/installFlowService.js
+++ b/marketplace-core/src/main/resources/web/js/services/installFlowService/installFlowService.js
@@ -15,10 +15,10 @@
 
 define(
     [
-      'marketplaceApp'
+      'marketplaceApp', 'marketplace-lib/Logger'
     ],
-    function ( app ) {
-      console.log("Required services/installFlowService/installFlowService.js");
+    function ( app, logger ) {
+      logger.log("Required services/installFlowService/installFlowService.js");
 
       var installFlowService = app.factory( 'installFlowService',
           [ 'appService', '$modal', '$translate',

--- a/marketplace-core/src/main/resources/web/lib/marketplace/Logger.js
+++ b/marketplace-core/src/main/resources/web/lib/marketplace/Logger.js
@@ -1,0 +1,125 @@
+/*!
+ * Copyright 2002 - 2015 Webdetails, a Pentaho company. All rights reserved.
+ *
+ * This software was developed by Webdetails and is provided under the terms
+ * of the Mozilla Public License, Version 2.0, or any later version. You may not use
+ * this file except in compliance with the license. If you need a copy of the license,
+ * please go to http://mozilla.org/MPL/2.0/. The Initial Developer is Webdetails.
+ *
+ * Software distributed under the Mozilla Public License is distributed on an "AS IS"
+ * basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. Please refer to
+ * the license for the specific language governing your rights and limitations.
+ */
+
+/**
+ * Logger module.
+ * Require as marketplace/Logger
+ *
+ * @class Logger
+ * @module Logger
+ */
+
+define(function() {
+
+  var logger = {
+
+    /**
+     *  Property enumerating the various log levels
+     *  @property logLevels
+     *  @type Array
+     */
+    loglevels: ['debug', 'log', 'info', 'warn', 'error', 'exception'],
+
+
+    /**
+     *  Current log level. Assign a new value to this property to change the log level
+     *  @property logLevel
+     *  @type string
+     */
+    loglevel: 'debug',
+
+    /**
+     *
+     * Logs a message at the specified log level
+     *
+     * @method log
+     * @param m Message to log
+     * @param type Log level. One of debug, info, warn, error or exception
+     * @param css CSS styling rules for the message to log
+     */
+    log: function(m, type, css) {    
+      type = type || "info";
+      if(this.loglevels.indexOf(type) < this.loglevels.indexOf(this.loglevel)) {
+        return;
+      }
+      if(typeof console !== "undefined") {
+
+        if(!console[type]) {
+          if(type === 'exception') {
+            type = "error";
+            m = m.stack || m;
+          } else {
+            type = "log";
+          }
+        }
+        if(css) {
+          try {
+            console[type]("%c[" + type + "] WD: " + m, css);
+            return;
+          } catch(e) {
+            // styling is not supported
+          }
+        }
+        console[type]("[" + type + "] WD: " + m);
+      }
+    },
+
+    /**
+     * Logs a message at debug level
+     * @method debug
+     * @param m Message to log
+     */
+    debug: function(m) {
+      return this.log(m, "debug");
+    },
+    /**
+     * Logs a message at info level
+     * @method info
+     * @param m Message to log
+     */
+
+    info: function(m) {
+      return this.log(m, "info");
+    },
+
+    /**
+     * Logs a message at warn level
+     * @method warn
+     * @param m Message to log
+     */
+    warn: function(m) {
+      return this.log(m, "warn");
+    },
+
+    /**
+     * Logs a message at error level
+     * @method error
+     * @param m Message to log
+     */
+    error: function(m) {
+      return this.log(m, "error");
+    },
+
+    /**
+     * Logs a message at exception level
+     * @method exception
+     * @param m Message to log
+     */
+    exception: function(m) {
+      return this.log(m, "exception");
+    }                       
+  };
+
+  return logger;
+
+});


### PR DESCRIPTION
Closes #82 (superseded).

Older versions of IE, particularly embedded ones and some other browsers/configurations, don't provide the window.console object if no Developer Tools are open/exist at all.

console.log and other methods must be avoided, using this module instead.