### PR TITLE
[MARKET-317] Force IE document mode to edge

### DIFF
--- a/marketplace-di/src/main/resources/web/main.html
+++ b/marketplace-di/src/main/resources/web/main.html
@@ -18,6 +18,8 @@
 
 <html>
     <head>
+        <meta http-equiv='x-ua-compatible' content='IE=edge' />
+
         <title>Marketplace</title>
 
         <!-- this is important, it provides theming and the base url -->


### PR DESCRIPTION
The embedded IE10 browser (in Windows 8) was falling into IE9 document mode
(even thou it rendered in IE10 document mode when directly in the browser).

This enables the text input data binding when pressing backspace, but only
on IE10 and later and not totally stable.

IE9 (and earlier) would need a fix available only in angular.js 1.4.x branch,
but we are using angular.js 1.2.x branch for IE8 compatibility.

@graimundo