### PR TITLE
[MARKET-320] Return cache control headers for /plugins

### DIFF
--- a/marketplace-core/pom.xml
+++ b/marketplace-core/pom.xml
@@ -39,6 +39,11 @@
     </dependency>
 
     <dependency>
+      <groupId>javax.servlet</groupId>
+      <artifactId>servlet-api</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>net.sf.flexjson</groupId>
       <artifactId>flexjson</artifactId>
     </dependency>

--- a/marketplace-core/pom.xml
+++ b/marketplace-core/pom.xml
@@ -40,7 +40,7 @@
 
     <dependency>
       <groupId>javax.servlet</groupId>
-      <artifactId>servlet-api</artifactId>
+      <artifactId>javax.servlet-api</artifactId>
     </dependency>
 
     <dependency>

--- a/marketplace-core/src/main/java/org/pentaho/marketplace/endpoints/MarketplaceService.java
+++ b/marketplace-core/src/main/java/org/pentaho/marketplace/endpoints/MarketplaceService.java
@@ -32,7 +32,9 @@ import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
+import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
+import javax.servlet.http.HttpServletResponse;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
@@ -75,7 +77,7 @@ public class MarketplaceService {
   @GET
   @Path( "/plugins" )
   @Produces( MediaType.APPLICATION_JSON )
-  public IterablePluginOperationResultDTO getPlugins() {
+  public IterablePluginOperationResultDTO getPlugins( @Context HttpServletResponse response ) {
 
     //get plugins from the domain model
     List<IPlugin> plugins = new ArrayList<>( this.RDO.getPluginService().getPlugins().values() );
@@ -94,6 +96,8 @@ public class MarketplaceService {
     //status message
     result.statusMessage.code = "OK_CODE";
     result.statusMessage.message = "OK_MESSAGE";
+
+    response.addHeader( "Cache-Control", "no-cache, no-store" );
 
     return result;
   }


### PR DESCRIPTION
IE10 was being more aggressive with cache, so every refresh resulted in 304 / NOT MODIFIED.
The user received no feedback, altrough the request was made.

Added header `Cache-Control: no-cache, no-store` to the response.

@graimundo