### PR TITLE
[CLEANUP] - Better debug logging when a plugin is not found on uninst…

### DIFF
--- a/marketplace-core/src/main/java/org/pentaho/marketplace/domain/services/BasePluginService.java
+++ b/marketplace-core/src/main/java/org/pentaho/marketplace/domain/services/BasePluginService.java
@@ -694,6 +694,11 @@ public abstract class BasePluginService implements IPluginService {
 
   private boolean executeUninstall( IPlugin plugin ) {
     IPluginVersion version =  this.getInstalledPluginVersion( plugin );
+    if ( version == null ) {
+      this.getLogger().debug( "Did not find plugin version for installed plugin: " + plugin.getId() );
+      return false;
+    }
+
     if ( version.isOsgi() ) {
       return this.executeOsgiUninstall( plugin );
     } else {

--- a/marketplace-di/src/main/java/org/pentaho/marketplace/domain/services/DiPluginService.java
+++ b/marketplace-di/src/main/java/org/pentaho/marketplace/domain/services/DiPluginService.java
@@ -149,6 +149,7 @@ public class DiPluginService extends BasePluginService {
     File pluginFolderFile = new File( pluginFolder );
 
     if ( !pluginFolderFile.exists() ) {
+      this.getLogger().debug( "Plugin " + plugin.getId() + " not found at expected folder " + pluginFolderFile.getPath() );
       return null;
     }
 


### PR DESCRIPTION
…all. This typically occurs because the plugin was deployed outside marketplace in the wrong folder.