### PR TITLE
[CHERRY-PICK][BACKLOG-11731] Fix bootstrap slider and remove unwanted border

### DIFF
--- a/marketplace-core/src/main/resources/web/css/marketplace.css
+++ b/marketplace-core/src/main/resources/web/css/marketplace.css
@@ -1265,6 +1265,10 @@ body.bootstrap .modal.confirmationDialog {
   margin-left: -205px;
 }
 
+body.bootstrap .modal.confirmationDialog .modal-dialog {
+  border: 0 none;
+}
+
 body.bootstrap .modal.confirmationDialog .dialog .title {
   font-size: 16px;
   padding-bottom: 20px;
@@ -1663,6 +1667,10 @@ body.bootstrap .modal.pluginDetailDialog .pluginScreenshots  .carousel-indicator
 	background-color: #fff \9;
 	background-color: rgba(0,0,0,0);
 	float: none;
+}
+
+body.bootstrap .modal.pluginDetailDialog .pluginScreenshots  .carousel-indicators li .sr-only {
+  display: none;
 }
 
 body.bootstrap .modal.pluginDetailDialog .pluginScreenshots  .carousel-indicators li.active {

--- a/marketplace-core/src/main/resources/web/directives/pluginDetail/pluginDetailTemplate.html
+++ b/marketplace-core/src/main/resources/web/directives/pluginDetail/pluginDetailTemplate.html
@@ -74,8 +74,8 @@
 
         <div data-ng-if="plugin.screenshotUrls && plugin.screenshotUrls.length > 0" class="pluginScreenshots">
           <div class="sectionHeader">{{ 'marketplace.pluginDetail.section.screenshots.title' | translate }}</div>
-          <div data-carousel data-interval="5000">
-            <div data-slide data-ng-repeat="screenshotUrl in plugin.screenshotUrls">
+          <div data-uib-carousel data-interval="5000" data-active="0">
+            <div data-uib-slide data-ng-repeat="screenshotUrl in plugin.screenshotUrls" data-index="$index">
               <img data-ng-src="{{screenshotUrl}}">
             </div>
           </div>


### PR DESCRIPTION
Includes part of https://github.com/pentaho/marketplace/pull/117. Does not include restoring the slider transition effect because it introduces a new dependency.