### PR TITLE
[BACKLOG-18961] Update cxf dependency to the pentaho overriden one

### DIFF
--- a/pentaho-marketplace-assembly/src/main/feature/feature.xml
+++ b/pentaho-marketplace-assembly/src/main/feature/feature.xml
@@ -7,6 +7,8 @@
 
     <feature>pentaho-requirejs-osgi-manager</feature>
 
+    <feature version="${cxf.karaf.version}">cxf-jaxrs</feature>
+
     <!-- START client side dependencies -->
     <bundle>pentaho-webjars:mvn:org.webjars.npm/underscore/${underscore.version}</bundle>
     <bundle>pentaho-webjars:mvn:org.webjars/jquery/${jquery.version}</bundle>

--- a/pom.xml
+++ b/pom.xml
@@ -79,7 +79,7 @@
     <dependency.pentaho-marketplace-core.id>pentaho-marketplace-core</dependency.pentaho-marketplace-core.id>
     <dependency.org.springframework.security.version>4.1.3.RELEASE</dependency.org.springframework.security.version>
     <angular-ui-bootstrap.version>1.3.3</angular-ui-bootstrap.version>
-    <cxf.karaf.version>3.0.7</cxf.karaf.version>
+    <cxf.karaf.version>3.0.7-pentaho</cxf.karaf.version>
     <dependency.pentaho-marketplace-di.id>pentaho-marketplace-di</dependency.pentaho-marketplace-di.id>
     <jquery.version>2.2.1</jquery.version>
     <underscore.version>1.8.3</underscore.version>


### PR DESCRIPTION
@pentaho/2-1b @graimundo 

Changes in line with the PR made to karaf [here](https://github.com/pentaho/pentaho-karaf-assembly/pull/374) to enforce the version of cxf to the pentaho overriden one.