### PR TITLE
[BACKLOG-18961] Set cxf version to defaul 3.0.7 after PPP-3850 was re…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,7 +79,7 @@
     <dependency.pentaho-marketplace-core.id>pentaho-marketplace-core</dependency.pentaho-marketplace-core.id>
     <dependency.org.springframework.security.version>4.1.3.RELEASE</dependency.org.springframework.security.version>
     <angular-ui-bootstrap.version>1.3.3</angular-ui-bootstrap.version>
-    <cxf.karaf.version>3.0.7-pentaho</cxf.karaf.version>
+    <cxf.karaf.version>3.0.7</cxf.karaf.version>
     <dependency.pentaho-marketplace-di.id>pentaho-marketplace-di</dependency.pentaho-marketplace-di.id>
     <jquery.version>2.2.1</jquery.version>
     <underscore.version>1.8.3</underscore.version>


### PR DESCRIPTION
@pentaho/2-1b @graimundo @pamval 

Setting cxf version to the default 3.0.7 since PPP-3850 was reverted. Will need updating if that moves forward. Would be nice to actually have a published version of the cxf feature (and other overriden features) if we are customising it so that this dependency could be enforced at build time.