### PR TITLE
[BACKLOG-22526] vulnerable component spring-security: upgrade from 4.…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -77,7 +77,7 @@
     <httpclient.version>4.5.3</httpclient.version>
     <angular-animate.version>${angular.version}</angular-animate.version>
     <dependency.pentaho-marketplace-core.id>pentaho-marketplace-core</dependency.pentaho-marketplace-core.id>
-    <dependency.org.springframework.security.version>4.1.3.RELEASE</dependency.org.springframework.security.version>
+    <dependency.org.springframework.security.version>4.1.5.RELEASE</dependency.org.springframework.security.version>
     <angular-ui-bootstrap.version>1.3.3</angular-ui-bootstrap.version>
     <cxf.karaf.version>3.0.13</cxf.karaf.version>
     <dependency.pentaho-marketplace-di.id>pentaho-marketplace-di</dependency.pentaho-marketplace-di.id>


### PR DESCRIPTION
…1.3 to 4.1.5

**Minor patch upgrade**: from 4.1.3 to 4.1.5

@pentaho/rogueone
CC'ing @pamval @dkincade @mbatchelor @mdamour1976 @graimundo

~Please **hold off** merging until we have triggered a PR for all necessary projects~ ✅ 

List of PRs
- https://github.com/pentaho/marketplace/pull/148
- https://github.com/pentaho/pentaho-metadata-editor-ee/pull/33
- https://github.com/pentaho/pentaho-metadata-editor/pull/122
- https://github.com/pentaho/pentaho-kettle/pull/5203
- https://github.com/pentaho/pentaho-platform/pull/4100
- https://github.com/pentaho/pentaho-platform-ee/pull/1257
- https://github.com/pentaho/pentaho-karaf-assembly/pull/437
- https://github.com/pentaho/pdi-ee-plugin/pull/356
- https://github.com/pentaho/pentaho-reportdesigner-ee/pull/105
- https://github.com/pentaho/pentaho-reporting/pull/1127
- https://github.com/pentaho/pentaho-osgi-bundles/pull/264