### PR TITLE
Revert "[BACKLOG-22526] vulnerable component spring-security: upgrade from 4.…"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -77,7 +77,7 @@
     <httpclient.version>4.5.3</httpclient.version>
     <angular-animate.version>${angular.version}</angular-animate.version>
     <dependency.pentaho-marketplace-core.id>pentaho-marketplace-core</dependency.pentaho-marketplace-core.id>
-    <dependency.org.springframework.security.version>4.1.5.RELEASE</dependency.org.springframework.security.version>
+    <dependency.org.springframework.security.version>4.1.3.RELEASE</dependency.org.springframework.security.version>
     <angular-ui-bootstrap.version>1.3.3</angular-ui-bootstrap.version>
     <cxf.karaf.version>3.0.13</cxf.karaf.version>
     <dependency.pentaho-marketplace-di.id>pentaho-marketplace-di</dependency.pentaho-marketplace-di.id>


### PR DESCRIPTION
Reverts pentaho/marketplace#148

@pentaho/rogueone @pamval @dkincade @mbatchelor @mdamour1976 @graimundo

**List or PRs**

- https://github.com/pentaho/marketplace/pull/149
- https://github.com/pentaho/pentaho-metadata-editor-ee/pull/37
- https://github.com/pentaho/pentaho-metadata-editor/pull/124
- https://github.com/pentaho/pentaho-kettle/pull/5275
- https://github.com/pentaho/pentaho-platform/pull/4111
- https://github.com/pentaho/pentaho-platform-ee/pull/1266
- https://github.com/pentaho/pentaho-karaf-assembly/pull/441
- https://github.com/pentaho/pdi-ee-plugin/pull/357
- https://github.com/pentaho/pentaho-reportdesigner-ee/pull/107
- https://github.com/pentaho/pentaho-reporting/pull/1134
- https://github.com/pentaho/pentaho-osgi-bundles/pull/265