### PR TITLE
[BACKLOG-21716] Remove pentaho-requirejs-osgi-manager dependency

### DIFF
--- a/marketplace-di/pom.xml
+++ b/marketplace-di/pom.xml
@@ -71,12 +71,6 @@
     </dependency>
     <dependency>
       <groupId>pentaho</groupId>
-      <artifactId>pentaho-requirejs-osgi-manager</artifactId>
-      <version>${project.version}</version>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>pentaho</groupId>
       <artifactId>pentaho-platform-extensions</artifactId>
       <version>${project.version}</version>
       <scope>provided</scope>


### PR DESCRIPTION
@pentaho/millenniumfalcon yet another consequence of https://github.com/pentaho/pentaho-osgi-bundles/pull/260.