### PR TITLE
[BACKLOG-22526] Use of vulnerable component spring-security 4.1.3 CVE…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -77,7 +77,7 @@
     <httpclient.version>4.5.3</httpclient.version>
     <angular-animate.version>${angular.version}</angular-animate.version>
     <dependency.pentaho-marketplace-core.id>pentaho-marketplace-core</dependency.pentaho-marketplace-core.id>
-    <dependency.org.springframework.security.version>4.1.3.RELEASE</dependency.org.springframework.security.version>
+    <dependency.org.springframework.security.version>4.1.5.RELEASE</dependency.org.springframework.security.version>
     <angular-ui-bootstrap.version>1.3.3</angular-ui-bootstrap.version>
     <cxf.karaf.version>3.0.13</cxf.karaf.version>
     <dependency.pentaho-marketplace-di.id>pentaho-marketplace-di</dependency.pentaho-marketplace-di.id>


### PR DESCRIPTION
…-2018-1199

**Minor patch upgrade**: from `4.1.3 RELEASE` to `4.1.5 RELEASE`

@pentaho/rogueone
CC'ing @pamval @dkincade @mbatchelor @mdamour1976 @graimundo

~Please **hold off** merging until we have triggered a PR for all necessary projects~ ✅ 

List of PRs:
- https://github.com/pentaho/pentaho-platform/pull/4229
- https://github.com/pentaho/pentaho-osgi-bundles/pull/288
- https://github.com/pentaho/pentaho-platform-ee/pull/1276
- https://github.com/pentaho/pentaho-kettle/pull/5750
- https://github.com/pentaho/pentaho-reporting/pull/1179
- https://github.com/pentaho/pentaho-reportdesigner-ee/pull/115
- https://github.com/pentaho/pdi-ee-plugin/pull/361
- https://github.com/pentaho/pentaho-karaf-assembly/pull/478
- https://github.com/pentaho/pentaho-metadata-editor/pull/128
- https://github.com/pentaho/pentaho-metadata-editor-ee/pull/38
- https://github.com/pentaho/marketplace/pull/152
