### PR TITLE
[BACKLOG-22526][CLEANUP] Promoting current spring-security.version to…

### DIFF
--- a/marketplace-ba/pom.xml
+++ b/marketplace-ba/pom.xml
@@ -74,7 +74,7 @@
     <dependency>
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-core</artifactId>
-      <version>${dependency.org.springframework.security.version}</version>
+      <version>${spring-security.version}</version>  <!-- see maven-parent-pom -->
     </dependency>
   </dependencies>
   <build>

--- a/pom.xml
+++ b/pom.xml
@@ -77,7 +77,6 @@
     <httpclient.version>4.5.3</httpclient.version>
     <angular-animate.version>${angular.version}</angular-animate.version>
     <dependency.pentaho-marketplace-core.id>pentaho-marketplace-core</dependency.pentaho-marketplace-core.id>
-    <dependency.org.springframework.security.version>4.1.5.RELEASE</dependency.org.springframework.security.version>
     <angular-ui-bootstrap.version>1.3.3</angular-ui-bootstrap.version>
     <cxf.karaf.version>3.0.13</cxf.karaf.version>
     <dependency.pentaho-marketplace-di.id>pentaho-marketplace-di</dependency.pentaho-marketplace-di.id>


### PR DESCRIPTION
… maven-parent-pom

**Notes**
- This is not changing the current version
  - we are merely promoting it to maven-parent-pom as a cleanup + centralization effort
- Wingman **will** fail on these
  - the referenced dependency property version `spring-security.version` is not yet in play 
  - see related PR adding it to maven-parent-pom: https://github.com/pentaho/maven-parent-poms/pull/71

@pentaho/rogueone @pentaho-lmartins

~Please **hold off** merging until we have triggered a PR for all necessary projects~ ✅

**List of PRs:**
- https://github.com/pentaho/maven-parent-poms/pull/71
- https://github.com/pentaho/marketplace/pull/153
- https://github.com/pentaho/pentaho-platform/pull/4231
- https://github.com/pentaho/pentaho-platform-ee/pull/1278
- https://github.com/pentaho/pentaho-kettle/pull/5752
- https://github.com/pentaho/pentaho-reporting/pull/1181
- https://github.com/pentaho/pdi-ee-plugin/pull/362
- https://github.com/pentaho/pentaho-osgi-bundles/pull/289
- https://github.com/pentaho/pentaho-metadata-editor-ee/pull/40
- https://github.com/pentaho/pentaho-reportdesigner-ee/pull/116
- https://github.com/pentaho/pentaho-metadata-editor/pull/130
- https://github.com/pentaho/pentaho-metadata-editor-ee/pull/40
