### PR TITLE
[BACKLOG-27641] - Letting maven-remote-resources-plugin version be se…

### DIFF
--- a/marketplace-ba/pom.xml
+++ b/marketplace-ba/pom.xml
@@ -121,7 +121,6 @@
       </plugin>
       <plugin>
         <artifactId>maven-remote-resources-plugin</artifactId>
-        <version>1.5</version>
         <executions>
           <execution>
             <id>process-remote-resources</id>

--- a/marketplace-core/pom.xml
+++ b/marketplace-core/pom.xml
@@ -125,7 +125,6 @@
     <plugins>
       <plugin>
         <artifactId>maven-remote-resources-plugin</artifactId>
-        <version>1.5</version>
         <executions>
           <execution>
             <goals>

--- a/marketplace-di/pom.xml
+++ b/marketplace-di/pom.xml
@@ -128,7 +128,6 @@
       </plugin>
       <plugin>
         <artifactId>maven-remote-resources-plugin</artifactId>
-        <version>1.5</version>
         <executions>
           <execution>
             <id>process-remote-resources</id>


### PR DESCRIPTION
…t by parent POM. In practice this is upgrading the version to be able to compile with openJDK 1.8

*note:* merge after https://github.com/pentaho/maven-parent-poms/pull/101

@nantunes please review