### PR TITLE
[SP-5528] Backport of PPP-4486 - Use of Vulnerable Component: commons…

### DIFF
--- a/marketplace-di/pom.xml
+++ b/marketplace-di/pom.xml
@@ -58,10 +58,6 @@
       <artifactId>commons-collections</artifactId>
     </dependency>
     <dependency>
-      <groupId>commons-codec</groupId>
-      <artifactId>commons-codec</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.apache.karaf.kar</groupId>
       <artifactId>org.apache.karaf.kar.core</artifactId>
     </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,6 @@
     <commons.collections.version>3.2.2</commons.collections.version>
     <angular-route.version>${angular.version}</angular-route.version>
     <paxexamversion>4.1.0</paxexamversion>
-    <commons.codec.version>1.5</commons.codec.version>
     <commons.io.version>2.4</commons.io.version>
     <angular-translate.version>2.12.1</angular-translate.version>
     <pentaho-osgi-bundles.version>9.0.0.0-SNAPSHOT</pentaho-osgi-bundles.version>
@@ -104,11 +103,6 @@
         <artifactId>javax.servlet-api</artifactId>
         <version>3.0.1</version>
         <scope>provided</scope>
-      </dependency>
-      <dependency>
-        <groupId>commons-codec</groupId>
-        <artifactId>commons-codec</artifactId>
-        <version>${commons.codec.version}</version>
       </dependency>
       <dependency>
         <groupId>commons-collections</groupId>


### PR DESCRIPTION
…-codec [Multiple Versions] (sonatype-2012-0050) (9.0 Suite)

Cherry-pick of #177 into 9.0 branch.
Please see https://github.com/pentaho/maven-parent-poms/pull/238 for details.