### PR TITLE
[BACKLOG-40823] - Upgrade the Tomcat version from current to 10.x.x with Java 17

### DIFF
--- a/marketplace-core/pom.xml
+++ b/marketplace-core/pom.xml
@@ -21,6 +21,10 @@
       <artifactId>javax.ws.rs-api</artifactId>
     </dependency>
     <dependency>
+      <groupId>com.fasterxml.jackson.jaxrs</groupId>
+      <artifactId>jackson-jaxrs-json-provider</artifactId>
+    </dependency>
+    <dependency>
       <groupId>commons-logging</groupId>
       <artifactId>commons-logging</artifactId>
     </dependency>

--- a/marketplace-core/pom.xml
+++ b/marketplace-core/pom.xml
@@ -23,6 +23,7 @@
     <dependency>
       <groupId>com.fasterxml.jackson.jaxrs</groupId>
       <artifactId>jackson-jaxrs-json-provider</artifactId>
+      <version>${fasterxml-jackson.version}</version>
     </dependency>
     <dependency>
       <groupId>commons-logging</groupId>
@@ -55,6 +56,11 @@
     <dependency>
       <groupId>org.hitachivantara.karaf.features</groupId>
       <artifactId>org.hitachivantara.karaf.features.core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>jakarta.xml.bind</groupId>
+      <artifactId>jakarta.xml.bind-api</artifactId>
+      <version>${jakarta.xml.bind-osgi.version}</version>
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>

--- a/marketplace-core/src/main/java/org/pentaho/marketplace/util/MarketplaceJaxbJsonProvider.java
+++ b/marketplace-core/src/main/java/org/pentaho/marketplace/util/MarketplaceJaxbJsonProvider.java
@@ -1,0 +1,27 @@
+/*! ******************************************************************************
+ *
+ * Pentaho
+ *
+ * Copyright (C) 2024 by Hitachi Vantara, LLC : http://www.pentaho.com
+ *
+ * Use of this software is governed by the Business Source License included
+ * in the LICENSE.TXT file.
+ *
+ * Change Date: 2029-07-20
+ ******************************************************************************/
+package org.pentaho.marketplace.util;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.jaxrs.json.JacksonJaxbJsonProvider;
+
+public class MarketplaceJaxbJsonProvider extends JacksonJaxbJsonProvider {
+  public MarketplaceJaxbJsonProvider() {
+    super( JacksonJaxbJsonProvider.DEFAULT_ANNOTATIONS );
+
+    ObjectMapper objectMapper = new ObjectMapper();
+    objectMapper.setSerializationInclusion( JsonInclude.Include.NON_NULL );
+    setMapper( objectMapper );
+  }
+
+}

--- a/marketplace-core/src/main/resources/OSGI-INF/blueprint/marketplace-core-blueprint.xml
+++ b/marketplace-core/src/main/resources/OSGI-INF/blueprint/marketplace-core-blueprint.xml
@@ -24,6 +24,9 @@
   http://cxf.apache.org/blueprint/core http://cxf.apache.org/schemas/blueprint/core.xsd">
 
   <cxf:bus id="marketplaceImplBus">
+    <cxf:properties>
+      <entry key="skip.default.json.provider.registration" value="true"/>
+    </cxf:properties>
   </cxf:bus>
 
   <jaxrs:server address="/marketplace" id="marketplaceService">
@@ -31,12 +34,7 @@
       <ref component-id="marketplaceServiceEndpoint"/>
     </jaxrs:serviceBeans>
     <jaxrs:providers>
-      <bean class="org.apache.cxf.jaxrs.provider.json.JSONProvider">
-        <property name="dropRootElement" value="true"/>
-        <property name="dropCollectionWrapperElement" value="true"/>
-        <property name="serializeAsArray" value="true"/>
-        <property name="supportUnwrapped" value="true"/>
-      </bean>
+      <bean id="jacksonProvider" class="org.pentaho.marketplace.util.MarketplaceJaxbJsonProvider"/>
     </jaxrs:providers>
   </jaxrs:server>
 


### PR DESCRIPTION
This pull request introduces a new custom JSON provider for the marketplace service, replacing the default JSON provider with one based on Jackson. The changes include updates to the Maven dependencies, the addition of a custom provider class, and modifications to the service configuration to integrate the new provider.

### Dependency Updates:
* Added `jackson-jaxrs-json-provider` dependency to `marketplace-core/pom.xml` for JSON processing with Jackson.
* Added `jakarta.xml.bind-api` dependency to `marketplace-core/pom.xml` to support JAXB-based operations.

### Custom JSON Provider:
* Introduced a new class, `MarketplaceJaxbJsonProvider`, extending `JacksonJaxbJsonProvider`. This class configures an `ObjectMapper` to exclude `null` values during serialization.

### Service Configuration:
* Updated `marketplace-core-blueprint.xml` to replace the default JSON provider with the new `MarketplaceJaxbJsonProvider`. Also, added a configuration to skip the default JSON provider registration.